### PR TITLE
Dynamic IP address list pulling, caching of IPs to text file in case of cloudflare.com downtime.

### DIFF
--- a/cloudflare/cloudflare.php
+++ b/cloudflare/cloudflare.php
@@ -3,7 +3,7 @@
 Plugin Name: CloudFlare
 Plugin URI: http://www.cloudflare.com/wiki/CloudFlareWordPressPlugin
 Description: CloudFlare integrates your blog with the CloudFlare platform.
-Version: 1.2.5.Beta
+Version: 1.3.6
 Author: Ian Pye, Jerome Chen, James Greene (CloudFlare Team)
 License: GPLv2
 */
@@ -26,64 +26,13 @@ Plugin adapted from the Akismet WP plugin.
 
 */	
 
-define('CLOUDFLARE_VERSION', '1.2.5.Beta');
+define('CLOUDFLARE_VERSION', '1.3.6');
 require_once("ip_in_range.php");
 
 // Make sure we don't expose any info if called directly
 if ( !function_exists( 'add_action' ) ) {
 	echo "Hi there!  I'm just a plugin, not much I can do when called directly.";
 	exit;
-}
-
-function cloudflare_pull_ip_list($ip_version=4)
-{
-    $cf_ip_ranges = array();
-
-    $plugin_dir = plugin_dir_path(__FILE__);
-    
-    if ($ip_version == 6) {
-        $ip_text_file = "ipv6_list.txt";
-        $ip_url = "https://www.cloudflare.com/ips-v6";
-        $ips_fallback_array = array("2400:cb00::/32", "2606:4700::/32", "2803:f800::/32");
-    }
-    else { // Default to ipv4
-        $ip_text_file = "ipv4_list.txt";
-        $ip_url = "https://www.cloudflare.com/ips-v4";
-        $ips_fallback_array = array("204.93.240.0/24", "204.93.177.0/24", "199.27.128.0/21", "173.245.48.0/20", "103.22.200.0/22", "141.101.64.0/18", "108.162.192.0/18","190.93.240.1/20");
-    }
-
-    // Let's get the IPs from the official cloudflare IPv<$ip_version> list URL, which has the latest up to date list.
-    $request_file_refresh = FALSE;
-    $ip_file_data = @file_get_contents($plugin_dir . $ip_text_file);
-    $last_modified = @filemtime($plugin_dir . $ip_text_file);
-    if ($last_modified === FALSE) {
-        $request_file_refresh = TRUE;
-    } else {
-        $time_since_last_update = time() - $last_modified;
-        if ($time_since_last_update > 86400) {
-            $request_file_refresh = TRUE;
-        }
-    }
-
-    if ($ip_file_data === FALSE || trim($ip_file_data) == "" || $request_file_refresh === TRUE) {
-        $live_ips_list = @file_get_contents($ip_url);
-        
-        if ($live_ips_list !== FALSE && trim($live_ips_list) != "") {
-            @file_put_contents($plugin_dir . $ip_text_file, $live_ips_list);
-            $cf_ip_ranges = explode("\n", $live_ips_list);
-        } else {
-            // Use the default static list for now, until we are able to access the live updated list again.
-            $cf_ip_ranges = $ips_fallback_array;
-        }
-    } else {
-        $cf_ip_ranges = explode("\n", $ip_file_data);
-    }
-
-    foreach ($cf_ip_ranges as $key=>$val) {
-        $cf_ip_ranges[$key] = trim($val);
-    }
-
-    return $cf_ip_ranges;
 }
 
 function cloudflare_init() {
@@ -95,8 +44,7 @@ function cloudflare_init() {
     $is_cf = ($_SERVER["HTTP_CF_CONNECTING_IP"])? TRUE: FALSE;    
 
     if (strpos($_SERVER["REMOTE_ADDR"], ":") === FALSE) {
-        $cf_ip_ranges = cloudflare_pull_ip_list(4);
-        
+        $cf_ip_ranges = array("204.93.240.0/24", "204.93.177.0/24", "199.27.128.0/21", "173.245.48.0/20", "103.22.200.0/22", "141.101.64.0/18", "108.162.192.0/18","190.93.240.1/20");
         // IPV4: Update the REMOTE_ADDR value if the current REMOTE_ADDR value is in the specified range.
         foreach ($cf_ip_ranges as $range) {
             if (ipv4_in_range($_SERVER["REMOTE_ADDR"], $range)) {
@@ -105,12 +53,10 @@ function cloudflare_init() {
                 }
                 break;
             }
-        }    
+        }        
     }
     else {
-        $cf_ip_ranges = cloudflare_pull_ip_list(6);
-        
-        // IPV6: Update the REMOTE_ADDR value if the current REMOTE_ADDR value is in the specified range.
+        $cf_ip_ranges = array("2400:cb00::/32", "2606:4700::/32", "2803:f800::/32");
         $ipv6 = get_ipv6_full($_SERVER["REMOTE_ADDR"]);
         foreach ($cf_ip_ranges as $range) {
             if (ipv6_in_range($ipv6, $range)) {
@@ -163,12 +109,18 @@ function cloudflare_conf() {
     $urlparts = parse_url(site_url());
     $raw_domain = $urlparts["host"];
 
-    // Attempt to get the matching host from CF
-    $domain = get_domain($cloudflare_api_key, $cloudflare_api_email, $raw_domain);
+    $curl_installed = function_exists('curl_init');
 
-    // If not found, default to pulling the domain via client side.
-    if (!$domain) {
-         $domain = $raw_domain;
+    if ($curl_installed) {
+        // Attempt to get the matching host from CF
+        $domain = get_domain($cloudflare_api_key, $cloudflare_api_email, $raw_domain);
+        // If not found, default to pulling the domain via client side.
+        if (!$domain) {
+             $domain = $raw_domain;
+        }
+    }
+    else {
+         $domain = $raw_domain;    
     }
     
     define ("THIS_DOMAIN",  $domain);
@@ -176,7 +128,6 @@ function cloudflare_conf() {
     $db_results = array();
                
 	if ( isset($_POST['submit']) 
-         && !($_POST['optimize']) 
          && check_admin_referer('cloudflare-db-api','cloudflare-db-api-nonce') ) {
         
 		if ( function_exists('current_user_can') && !current_user_can('manage_options') ) {
@@ -207,56 +158,33 @@ function cloudflare_conf() {
             update_option('cloudflare_api_email_set_once', "TRUE");
         }
 
-        if ($key != "" && $email != "") {
-            set_dev_mode(esc_sql($key), esc_sql($email), THIS_DOMAIN, $dev_mode);
-            if ($dev_mode) {
-                $ms[] = 'dev_mode_on';
-            }
-            else {
-                $ms[] = 'dev_mode_off';
-            }
-        }
 
         $messages = array(
                           'new_key_empty' => array('color' => 'aa0', 'text' => __('Your key has been cleared.')),
                           'new_key_valid' => array('color' => '2d2', 'text' => __('Your key has been verified. Happy blogging!')),
                           'new_email_empty' => array('color' => 'aa0', 'text' => __('Your email has been cleared.')),
-                          'new_email_valid' => array('color' => '2d2', 'text' => __('Your email has been verified. Happy blogging!')),
-                          'dev_mode_on' => array('color' => '2d2', 'text' => __('Development mode is On. Happy blogging!')),
-                          'dev_mode_off' => array('color' => 'aa0', 'text' => __('Development mode is Off. Happy blogging!'))
+                          'new_email_valid' => array('color' => '2d2', 'text' => __('Your email has been verified. Happy blogging!'))
                           );
-    } else if ( isset($_POST['submit']) 
-                && isset($_POST['optimize'])
-                && check_admin_referer('cloudflare-db-opt','cloudflare-db-opt-nonce')) {
 
-        update_option('cloudflare_api_db_last_run', time());
-        if(current_user_can('administrator')) {
-            remove_action('admin_notices', 'cloudflare_warning');
-            $tables = $wpdb->get_col("SHOW TABLES");
-            foreach($tables as $table_name) {
-                $optimize = $wpdb->query("OPTIMIZE TABLE `$table_name`");
-                $analyze = $wpdb->query("ANALYZE TABLE `$table_name`");
-                if (!$optimize || !$analyze) {
-                    $db_results[] = "Error optimizing $table_name";
+        if ($curl_installed) {
+            if ($key != "" && $email != "") {
+                set_dev_mode(esc_sql($key), esc_sql($email), THIS_DOMAIN, $dev_mode);
+                if ($dev_mode) {
+                    $ms[] = 'dev_mode_on';
+                }
+                else {
+                    $ms[] = 'dev_mode_off';
                 }
             }
-            if (count($db_results) == 0) {
-                $db_results[] = "All tables optimized without error.";
-            }
-        } else {
-            $db_results[] = "The current user does not have the permission \"manage_database\". Please run the command again with an appropriate user.";
+        
+            $messages['dev_mode_on'] = array('color' => '2d2', 'text' => __('Development mode is On. Happy blogging!'));
+            $messages['dev_mode_off'] = array('color' => 'aa0', 'text' => __('Development mode is Off. Happy blogging!'));
         }
     }
-
     ?>
-    <?php if ( !empty($_POST['submit'] ) && !($_POST['optimize']) ) { ?>
+    <?php if ( !empty($_POST['submit'] )) { ?>
     <div id="message" class="updated fade"><p><strong><?php _e('Options saved.') ?></strong></p></div>
-    <?php } else if ( isset($_POST['submit']) && isset($_POST['optimize']) ) {
-    foreach ($db_results as $res) {
-        ?><div id="message" class="updated fade"><p><strong><?php _e($res) ?></strong></p></div><?php
-    }
-} 
-    ?>
+    <?php } ?>
     <div class="wrap">
 
     <?php if ($is_cf) { ?>
@@ -265,10 +193,6 @@ function cloudflare_conf() {
 
     <h4><?php _e('CLOUDFLARE WORDPRESS PLUGIN:'); ?></h4>
         <?php //    <div class="narrow"> ?>
-
-<u>**IMPORTANT NOTE: THIS IS A BETA VERSION OF THE CLOUDFLARE PLUGIN**</u><br/><br/>
-
-<u>If you experience any major issues related to this plugin version, please revert back to the previous stable version (1.2.4).</u><br/><br/>
 
 CloudFlare has developed a plugin for WordPress. By using the CloudFlare WordPress Plugin, you receive: 
 <ol>
@@ -286,8 +210,6 @@ The plugin is compatible with WordPress version 2.8.6 and later. The plugin will
 <ol>
 <li>The main purpose of this plugin is to ensure you have no change to your originating IPs when using CloudFlare. Since CloudFlare acts a reverse proxy, connecting IPs now come from CloudFlare's range. This plugin will ensure you can continue to see the originating IP. Once you install the plugin, the IP benefit will be activated.</li>
  
-<li>This plugin can also help to ensure your server database is running optimally. If you are going to run the Database Optimizer associated with this plugin, then run it at a low traffic time. While the Database Optimizer is running, your site will go into Read Only mode, which means that you or your visitors will not be allowed to post. The optimizer should run quickly. Once the optimizer is done running, you will be able to post to your site again. To run the Database Optimizer, click the icon below.</li>
-
 <li>Every time you click the 'spam' button on your blog, this threat information is sent to CloudFlare to ensure you are constantly getting the best site protection.</li>
 
 <li>We recommend that any user on CloudFlare with WordPress use this plugin. </li>
@@ -301,8 +223,9 @@ The plugin is compatible with WordPress version 2.8.6 and later. The plugin will
 CloudFlare is a service that makes websites load faster and protects sites from online spammers and hackers. Any website with a root domain (ie www.mydomain.com) can use CloudFlare. On average, it takes less than 5 minutes to sign up. You can learn more here: <a href="http://www.cloudflare.com/">CloudFlare.com</a>.
 
     <?php 
-// if ($is_cf) {
-        $dev_mode = get_dev_mode_status($cloudflare_api_key, $cloudflare_api_email, THIS_DOMAIN);
+        if ($curl_installed) {
+            $dev_mode = get_dev_mode_status($cloudflare_api_key, $cloudflare_api_email, THIS_DOMAIN);
+        }
     ?>
 
     <hr />
@@ -321,26 +244,18 @@ CloudFlare is a service that makes websites load faster and protects sites from 
     <h3><label for="email"><?php _e('CloudFlare API Email'); ?></label></h3>
     <p><input id="email" name="email" type="text" size="50" maxlength="48" value="<?php echo get_option('cloudflare_api_email'); ?>" style="font-family: 'Courier New', Courier, mono; font-size: 1.5em;" /> (<?php _e('<a href="https://www.cloudflare.com/my-account.html">Get this?</a>'); ?>)
     <h3><label for="dev_mode"><?php _e('Development Mode'); ?></label> <span style="font-size:9pt;">(<a href="http://support.cloudflare.com/kb/what-do-the-various-cloudflare-settings-do/what-does-cloudflare-development-mode-mean" " target="_blank">What is this?</a>)</span></h3>
-   <div style="font-family: 'Courier New', Courier, mono; font-size: 1.5em;">
-   <input type="radio" name="dev_mode" value="0" <? if ($dev_mode == "off") echo "checked"; ?>> Off
-   <input type="radio" name="dev_mode" value="1" <? if ($dev_mode == "on") echo "checked"; ?>> On
-  </div>
-    </p>
 
-    <p class="submit"><input type="submit" name="submit" value="<?php _e('Update options &raquo;'); ?>" /></p>
-    </form>
+    <? if ($curl_installed) { ?>
+    <div style="font-family: 'Courier New', Courier, mono; font-size: 1.5em;">
+    <input type="radio" name="dev_mode" value="0" <? if ($dev_mode == "off") echo "checked"; ?>> Off
+    <input type="radio" name="dev_mode" value="1" <? if ($dev_mode == "on") echo "checked"; ?>> On
+    </div>
+    <? } else { ?>
+    You cannot toggle development mode because cURL is not installed for your domain.  Please contact a server administrator for assistance with installing cURL.
+    <? } ?>
     
-    <?php 
-    // } 
-    ?>
-
-    <form action="" method="post" id="cloudflare-db">
-    <?php wp_nonce_field('cloudflare-db-opt','cloudflare-db-opt-nonce'); ?>
-    <input type="hidden" name="optimize" value="1" />
-
-    <h4><label for="optimize_db"><?php _e('DATABASE OPTIMIZER (optional): Make your site run even faster.'); ?></label>
-    <input type="submit" name="submit" value="<?php _e('Run the optimizer'); ?>" /> (<?php _e('<a href="http://www.cloudflare.com/wiki/WordPressDBOptimizer">What is this?</a>'); ?>)</h4>
-
+    </p>
+    <p class="submit"><input type="submit" name="submit" value="<?php _e('Update options &raquo;'); ?>" /></p>
     </form>
 
         <?php //    </div> ?>
@@ -351,42 +266,7 @@ CloudFlare is a service that makes websites load faster and protects sites from 
 function cloudflare_admin_warnings() {
     
     global $cloudflare_api_key, $cloudflare_api_email; 
-    load_cloudflare_keys();
-
-    /**
-	if ( !get_option('cloudflare_api_key_set_once') && !$cloudflare_api_key && !isset($_POST['submit']) ) {
-		function cloudflare_warning() {
-			echo "
-			<div id='cloudflare-warning' class='updated fade'><p><strong>".__('CloudFlare is almost ready.')."</strong> ".sprintf(__('You must <a href="%1$s">enter your CloudFlare API key</a> for it to work.'), "plugins.php?page=cloudflare")."</p></div>
-			";
-		}
-		add_action('admin_notices', 'cloudflare_warning');
-		return;
-	} else if ( !get_option('cloudflare_api_key_set_once') && !$cloudflare_api_email && !isset($_POST['submit']) ) {
-		function cloudflare_warning() {
-			echo "
-			<div id='cloudflare-warning' class='updated fade'><p><strong>".__('CloudFlare is almost ready.')."</strong> ".sprintf(__('You must <a href="%1$s">enter your CloudFlare API email</a> for it to work.'), "plugins.php?page=cloudflare")."</p></div>
-			";
-		}
-		add_action('admin_notices', 'cloudflare_warning');
-		return;
-	} 
-    */
-    
-    // Check to see if they should optimized their DB
-    $last_run_time = (int)get_option('cloudflare_api_db_last_run');
-    if (!$last_run_time) {
-        $last_run_time = time();
-    }
-    if (time() - $last_run_time > 5259487) { // 2 Months (avg)
-        function cloudflare_warning() {
-			echo "
-			<div id='cloudflare-warning' class='updated fade'><p><strong>".__('Your Database is due to be optimized again.')."</strong> ".sprintf(__('We recommend that you <a href="%1$s">run the CloudFlare optimizer</a> every two months to keep your blog running quickly. It\'s time to run it again.'), "plugins.php?page=cloudflare")."</p></div>
-			";
-		}
-		add_action('admin_notices', 'cloudflare_warning');
-		return;
-    }
+    load_cloudflare_keys();    
 }
 
 // Now actually allow CF to see when a comment is approved/not-approved.

--- a/cloudflare/cloudflare.php
+++ b/cloudflare/cloudflare.php
@@ -3,8 +3,8 @@
 Plugin Name: CloudFlare
 Plugin URI: http://www.cloudflare.com/wiki/CloudFlareWordPressPlugin
 Description: CloudFlare integrates your blog with the CloudFlare platform.
-Version: 1.2.3
-Author: Ian Pye, Jerome Chen (CloudFlare Team)
+Version: 1.2.4
+Author: Ian Pye, Jerome Chen, James Greene (CloudFlare Team)
 License: GPLv2
 */
 
@@ -26,7 +26,7 @@ Plugin adapted from the Akismet WP plugin.
 
 */	
 
-define('CLOUDFLARE_VERSION', '1.2.1');
+define('CLOUDFLARE_VERSION', '1.2.4');
 require_once("ip_in_range.php");
 
 // Make sure we don't expose any info if called directly
@@ -36,16 +36,16 @@ if ( !function_exists( 'add_action' ) ) {
 }
 
 function cloudflare_init() {
-	global $cf_api_host, $cf_api_port, $is_cf;
+    global $cf_api_host, $cf_api_port, $is_cf;
 
     $cf_api_host = "ssl://www.cloudflare.com";
     $cf_api_port = 443;
-    // Let's get the IPs from the official cloudflare IPv4 list URL, which has the latest up to date list.
-    
-    $request_file_refresh = FALSE;
+    $plugin_dir = plugin_dir_path(__FILE__);
 
-    $ipv4_file_data = @file_get_contents("ipv4_list.txt");
-    $last_modified = @filemtime("ipv4_list.txt");
+    // Let's get the IPs from the official cloudflare IPv4 list URL, which has the latest up to date list.
+    $request_file_refresh = FALSE;
+    $ipv4_file_data = @file_get_contents($plugin_dir . "ipv4_list.txt");
+    $last_modified = @filemtime($plugin_dir . "ipv4_list.txt");
     if ($last_modified === FALSE) {
         $request_file_refresh = TRUE;
     } else {
@@ -59,7 +59,7 @@ function cloudflare_init() {
         $live_ips_v4_list = @file_get_contents("https://www.cloudflare.com/ips-v4");
         
         if ($live_ips_v4_list !== FALSE && trim($live_ips_v4_list) != "") {
-            file_put_contents("ipv4_list.txt", $live_ips_v4_list);
+            @file_put_contents($plugin_dir . "ipv4_list.txt", $live_ips_v4_list);
             $cf_ip_ranges = explode("\n", $live_ips_v4_list);
         } else {
             // Use the default static list for now, until we are able to access the live updated list again.
@@ -89,8 +89,8 @@ function cloudflare_init() {
     if (!headers_sent()) {
         header("X-CF-Powered-By: WP " . CLOUDFLARE_VERSION);
     }
-	add_action('admin_menu', 'cloudflare_config_page');
-	cloudflare_admin_warnings();
+    add_action('admin_menu', 'cloudflare_config_page');
+    cloudflare_admin_warnings();
 }
 add_action('init', 'cloudflare_init',1);
 

--- a/cloudflare/cloudflare.php
+++ b/cloudflare/cloudflare.php
@@ -69,7 +69,6 @@ function cloudflare_init() {
         $cf_ip_ranges = explode("\n", $ipv4_file_data);
     }
 
-
     foreach ($cf_ip_ranges as $key=>$val) {
         $cf_ip_ranges[$key] = trim($val);
     }

--- a/cloudflare/cloudflare.php
+++ b/cloudflare/cloudflare.php
@@ -50,7 +50,7 @@ function cloudflare_init() {
         $request_file_refresh = TRUE;
     } else {
         $time_since_last_update = time() - $last_modified;
-        if ($time_since_last_update > 40) {
+        if ($time_since_last_update > 86400) {
             $request_file_refresh = TRUE;
         }
     }

--- a/cloudflare/cloudflare.php
+++ b/cloudflare/cloudflare.php
@@ -40,7 +40,12 @@ function cloudflare_init() {
 
     $cf_api_host = "ssl://www.cloudflare.com";
     $cf_api_port = 443;
-    $cf_ip_ranges = array("204.93.240.0/24", "204.93.177.0/24", "199.27.128.0/21", "173.245.48.0/20", "103.22.200.0/22", "141.101.64.0/18", "108.162.192.0/18","190.93.240.0/20");
+    // Let's get the IPs from the official cloudflare IPv4 list URL, which has the latest up to date list.
+    $ips_v4_list = file_get_contents("https://www.cloudflare.com/ips-v4");
+    $cf_ip_ranges = explode("\n", $ips_v4_list);
+    foreach ($cf_ip_ranges as $key=>$val) {
+        $cf_ip_ranges[$key] = trim($val);
+    }
     $is_cf = ($_SERVER["HTTP_CF_CONNECTING_IP"])? TRUE: FALSE;    
 
     // Update the REMOTE_ADDR value if the current REMOTE_ADDR value is in the specified range.

--- a/cloudflare/cloudflare.php
+++ b/cloudflare/cloudflare.php
@@ -41,11 +41,39 @@ function cloudflare_init() {
     $cf_api_host = "ssl://www.cloudflare.com";
     $cf_api_port = 443;
     // Let's get the IPs from the official cloudflare IPv4 list URL, which has the latest up to date list.
-    $ips_v4_list = file_get_contents("https://www.cloudflare.com/ips-v4");
-    $cf_ip_ranges = explode("\n", $ips_v4_list);
+    
+    $request_file_refresh = FALSE;
+
+    $ipv4_file_data = @file_get_contents("ipv4_list.txt");
+    $last_modified = @filemtime("ipv4_list.txt");
+    if ($last_modified === FALSE) {
+        $request_file_refresh = TRUE;
+    } else {
+        $time_since_last_update = time() - $last_modified;
+        if ($time_since_last_update > 40) {
+            $request_file_refresh = TRUE;
+        }
+    }
+
+    if ($ipv4_file_data === FALSE || trim($ipv4_file_data) == "" || $request_file_refresh === TRUE) {
+        $live_ips_v4_list = @file_get_contents("https://www.cloudflare.com/ips-v4");
+        
+        if ($live_ips_v4_list !== FALSE && trim($live_ips_v4_list) != "") {
+            file_put_contents("ipv4_list.txt", $live_ips_v4_list);
+            $cf_ip_ranges = explode("\n", $live_ips_v4_list);
+        } else {
+            // Use the default static list for now, until we are able to access the live updated list again.
+            $cf_ip_ranges = array("204.93.240.0/24", "204.93.177.0/24", "199.27.128.0/21", "173.245.48.0/20", "103.22.200.0/22", "141.101.64.0/18", "108.162.192.0/18","190.93.240.0/20");
+        }
+    } else {
+        $cf_ip_ranges = explode("\n", $ipv4_file_data);
+    }
+
+
     foreach ($cf_ip_ranges as $key=>$val) {
         $cf_ip_ranges[$key] = trim($val);
     }
+ 
     $is_cf = ($_SERVER["HTTP_CF_CONNECTING_IP"])? TRUE: FALSE;    
 
     // Update the REMOTE_ADDR value if the current REMOTE_ADDR value is in the specified range.

--- a/cloudflare/ip_in_range.php
+++ b/cloudflare/ip_in_range.php
@@ -27,6 +27,12 @@
  * Please do not remove this header, or source attibution from this file.
  */
 
+/*
+* Modified by James Greene <james@cloudflare.com> to include IPV6 support
+* (original version only supported IPV4).
+* 21 May 2012 
+*/
+
 
 // decbin32
 // In order to simplify working with IP addresses (in binary) and their
@@ -36,7 +42,7 @@ function decbin32 ($dec) {
     return str_pad(decbin($dec), 32, '0', STR_PAD_LEFT);
 }
 
-// ip_in_range
+// ipv4_in_range
 // This function takes 2 arguments, an IP address and a "range" in several
 // different formats.
 // Network ranges can be specified as:
@@ -46,7 +52,7 @@ function decbin32 ($dec) {
 // The function will return true if the supplied IP is within the range.
 // Note little validation is done on the range inputs - it expects you to
 // use one of the above 3 formats.
-function ip_in_range($ip, $range) {
+function ipv4_in_range($ip, $range) {
     if (strpos($range, '/') !== false) {
         // $range is in IP/NETMASK format
         list($range, $netmask) = explode('/', $range, 2);
@@ -92,5 +98,117 @@ function ip_in_range($ip, $range) {
         }
         return false;
     } 
+}
+
+function ip2long6($ip) {
+    if (substr_count($ip, '::')) { 
+        $ip = str_replace('::', str_repeat(':0000', 8 - substr_count($ip, ':')) . ':', $ip); 
+    } 
+        
+    $ip = explode(':', $ip);
+    $r_ip = ''; 
+    foreach ($ip as $v) {
+        $r_ip .= str_pad(base_convert($v, 16, 2), 16, 0, STR_PAD_LEFT); 
+    } 
+        
+    return base_convert($r_ip, 2, 10); 
+} 
+
+// Get the ipv6 full format and return it as a decimal value.
+function get_ipv6_full($ip)
+{
+    $pieces = explode ("/", $ip, 2);
+    $left_piece = $pieces[0];
+    $right_piece = $pieces[1];
+
+    // Extract out the main IP pieces
+    $ip_pieces = explode("::", $left_piece, 2);
+    $main_ip_piece = $ip_pieces[0];
+    $last_ip_piece = $ip_pieces[1];
+
+    // Pad out the shorthand entries.
+    $main_ip_pieces = explode(":", $main_ip_piece);
+    foreach($main_ip_pieces as $key=>$val) {
+        $main_ip_pieces[$key] = str_pad($main_ip_pieces[$key], 4, "0", STR_PAD_LEFT);
+    }
+
+    // Check to see if the last IP block (part after ::) is set
+    $last_piece = "";
+    $size = count($main_ip_pieces);
+    if (trim($last_ip_piece) != "") {
+        $last_piece = str_pad($last_ip_piece, 4, "0", STR_PAD_LEFT);
+    
+        // Build the full form of the IPV6 address considering the last IP block set
+        for ($i = $size; $i < 7; $i++) {
+            $main_ip_pieces[$i] = "0000";
+        }
+        $main_ip_pieces[7] = $last_piece;
+    }
+    else {
+        // Build the full form of the IPV6 address
+        for ($i = $size; $i < 8; $i++) {
+            $main_ip_pieces[$i] = "0000";
+        }        
+    }
+    
+    // Rebuild the final long form IPV6 address
+    $final_ip = implode(":", $main_ip_pieces);
+
+    return ip2long6($final_ip);
+}
+
+
+// Determine whether the IPV6 address is within range.
+// $ip is the IPV6 address in decimal format to check if its within the IP range created by the cloudflare IPV6 address, $range_ip. 
+// $ip and $range_ip are converted to full IPV6 format.
+// Returns true if the IPV6 address, $ip,  is within the range from $range_ip.  False otherwise.
+function ipv6_in_range($ip, $range_ip)
+{
+    $pieces = explode ("/", $range_ip, 2);
+    $left_piece = $pieces[0];
+    $right_piece = $pieces[1];
+
+    // Extract out the main IP pieces
+    $ip_pieces = explode("::", $left_piece, 2);
+    $main_ip_piece = $ip_pieces[0];
+    $last_ip_piece = $ip_pieces[1];
+
+    // Pad out the shorthand entries.
+    $main_ip_pieces = explode(":", $main_ip_piece);
+    foreach($main_ip_pieces as $key=>$val) {
+        $main_ip_pieces[$key] = str_pad($main_ip_pieces[$key], 4, "0", STR_PAD_LEFT);
+    }
+
+    // Create the first and last pieces that will denote the IPV6 range.
+    $first = $main_ip_pieces;
+    $last = $main_ip_pieces;
+
+    // Check to see if the last IP block (part after ::) is set
+    $last_piece = "";
+    $size = count($main_ip_pieces);
+    if (trim($last_ip_piece) != "") {
+        $last_piece = str_pad($last_ip_piece, 4, "0", STR_PAD_LEFT);
+    
+        // Build the full form of the IPV6 address considering the last IP block set
+        for ($i = $size; $i < 7; $i++) {
+            $first[$i] = "0000";
+            $last[$i] = "ffff";
+        }
+        $main_ip_pieces[7] = $last_piece;
+    }
+    else {
+        // Build the full form of the IPV6 address
+        for ($i = $size; $i < 8; $i++) {
+            $first[$i] = "0000";
+            $last[$i] = "ffff";
+        }        
+    }
+
+    // Rebuild the final long form IPV6 address
+    $first = ip2long6(implode(":", $first));
+    $last = ip2long6(implode(":", $last));
+    $in_range = ($ip >= $first && $ip <= $last);
+
+    return $in_range;
 }
 ?>

--- a/cloudflare/readme.txt
+++ b/cloudflare/readme.txt
@@ -1,9 +1,9 @@
 === CloudFlare ===
-Contributors: i3149, jchen329
+Contributors: i3149, jchen329, jamescf
 Tags: cloudflare, comments, spam, cdn, free, website, performance, speed
 Requires at least: 2.8
 Tested up to: 3.3
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 License: GPLv2
 
 The CloudFlare WordPress Plugin ensures your WordPress blog is running optimally on the CloudFlare platform.
@@ -41,6 +41,9 @@ You will also want to sign up your blog with CloudFlare.com
 [Read more](http://blog.cloudflare.com/introducing-the-cloudflare-wordpress-plugin) on why we created this plugin.
 
 == Changelog ==
+
+= 1.2.4 =  
+* Pull the IP range from https://www.cloudflare.com/ips-v4.  Modified to keep all files within cloudflare plugin directory.
 
 = 1.2.3 =  
 * Updated with new IP range

--- a/cloudflare/readme.txt
+++ b/cloudflare/readme.txt
@@ -3,7 +3,7 @@ Contributors: i3149, jchen329, jamescf
 Tags: cloudflare, comments, spam, cdn, free, website, performance, speed
 Requires at least: 2.8
 Tested up to: 3.3
-Stable tag: 1.2.4
+Stable tag: 1.3.6
 License: GPLv2
 
 The CloudFlare WordPress Plugin ensures your WordPress blog is running optimally on the CloudFlare platform.
@@ -41,8 +41,19 @@ You will also want to sign up your blog with CloudFlare.com
 [Read more](http://blog.cloudflare.com/introducing-the-cloudflare-wordpress-plugin) on why we created this plugin.
 
 == Changelog ==
+= 1.3.6 =
+* Remove Database Optimizer.
 
-= 1.2.5.Beta =  
+= 1.3.5 =
+* Disable Development Mode option if cURL not installed.  Will Use JSONP in future release to allow domains without cURL to use Development Mode.
+
+= 1.3.4 =
+* Add in IPV6 support and Development Mode option to wordpress plugin settings page.  Remove cached IP range text file.
+
+= 1.3.3 =
+* Bump stable version number.
+
+= 1.3.2.Beta =  
 * BETA RELEASE: IPv6 support - Pull the IPv6 range from https://www.cloudflare.com/ips-v6.  Added Development Mode option to wordpress plugin settings page.
 
 = 1.2.4 =  

--- a/cloudflare/readme.txt
+++ b/cloudflare/readme.txt
@@ -3,7 +3,7 @@ Contributors: i3149, jchen329, jamescf
 Tags: cloudflare, comments, spam, cdn, free, website, performance, speed
 Requires at least: 2.8
 Tested up to: 3.3
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 License: GPLv2
 
 The CloudFlare WordPress Plugin ensures your WordPress blog is running optimally on the CloudFlare platform.
@@ -41,6 +41,9 @@ You will also want to sign up your blog with CloudFlare.com
 [Read more](http://blog.cloudflare.com/introducing-the-cloudflare-wordpress-plugin) on why we created this plugin.
 
 == Changelog ==
+
+= 1.2.5.Beta =  
+* BETA RELEASE: IPv6 support - Pull the IPv6 range from https://www.cloudflare.com/ips-v6.  Added Development Mode option to wordpress plugin settings page.
 
 = 1.2.4 =  
 * Pull the IP range from https://www.cloudflare.com/ips-v4.  Modified to keep all files within cloudflare plugin directory.


### PR DESCRIPTION
1) Pull IPs from live IP list on https://www.cloudflare.com/ips-v4
2) Cache the list to text file, ipv4_list.txt and use this unless the text file has expired (1 day from time of last pull of IPs from live IP list).
3) ipv4_list.txt must have write permissions from the plugin itself.
4) If everything is failing, default to using statically generated IP list hard-coded into cloudflare.php until able to grab the live IP list again. 
